### PR TITLE
fix(list): breaks when it has alternating operators

### DIFF
--- a/src/exec/exec_list.c
+++ b/src/exec/exec_list.c
@@ -6,7 +6,7 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/22 22:24:20 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/03 17:58:03 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/04 22:35:16 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,26 +14,40 @@
 
 void	exec_and(t_node *node, t_context *ctx)
 {
-	t_node	*lhs;
-	t_node	*rhs;
+	t_node		*lhs;
+	t_node		*rhs;
+	t_context	aux_ctx;
 
 	lhs = node->data.pair.left;
-	rhs = node->data.pair.right;
-	exec_node(lhs, ctx);
+	aux_ctx = *ctx;
+	exec_node(lhs, &aux_ctx);
+	ctx->proc_queue = aux_ctx.proc_queue;
 	reaper(ctx);
 	if (ctx->retcode == EXIT_SUCCESS)
-		exec_node(rhs, ctx);
+	{
+		aux_ctx = *ctx;
+		rhs = node->data.pair.right;
+		exec_node(rhs, &aux_ctx);
+		reaper(&aux_ctx);
+	}
 }
 
 void	exec_or(t_node *node, t_context *ctx)
 {
-	t_node	*lhs;
-	t_node	*rhs;
+	t_node		*lhs;
+	t_node		*rhs;
+	t_context	aux_ctx;
 
 	lhs = node->data.pair.left;
-	rhs = node->data.pair.right;
-	exec_node(lhs, ctx);
+	aux_ctx = *ctx;
+	exec_node(lhs, &aux_ctx);
+	ctx->proc_queue = aux_ctx.proc_queue;
 	reaper(ctx);
 	if (ctx->retcode != EXIT_SUCCESS)
-		exec_node(rhs, ctx);
+	{
+		aux_ctx = *ctx;
+		rhs = node->data.pair.right;
+		exec_node(rhs, &aux_ctx);
+		reaper(&aux_ctx);
+	}
 }

--- a/src/exec/exec_list.c
+++ b/src/exec/exec_list.c
@@ -6,7 +6,7 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/22 22:24:20 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/04 22:35:16 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/04 23:30:57 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,7 @@ void	exec_and(t_node *node, t_context *ctx)
 		rhs = node->data.pair.right;
 		exec_node(rhs, &aux_ctx);
 		reaper(&aux_ctx);
+		ctx->retcode = aux_ctx.retcode;
 	}
 }
 
@@ -49,5 +50,6 @@ void	exec_or(t_node *node, t_context *ctx)
 		rhs = node->data.pair.right;
 		exec_node(rhs, &aux_ctx);
 		reaper(&aux_ctx);
+		ctx->retcode = aux_ctx.retcode;
 	}
 }

--- a/src/parser/grammar/rules1.c
+++ b/src/parser/grammar/rules1.c
@@ -6,11 +6,13 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/27 18:34:00 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/04 08:06:59 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/04 17:38:31 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
+
+static t_node	*and_or(t_node_type type, t_node *pipe, t_node *logical);
 
 // list -> pipeline conditional
 t_node	*list(t_scanner *scanner)
@@ -52,17 +54,13 @@ t_node	*conditional(t_scanner *scanner)
 	{
 		pipe = pipeline(scanner);
 		logical = conditional(scanner);
-		if (logical)
-			return (mknode(logical->type, mknode(AND, NULL, pipe), logical));
-		return (mknode(AND, NULL, pipe));
+		return (and_or(AND, pipe, logical));
 	}
 	if (match(TOKEN_OR, scanner))
 	{
 		pipe = pipeline(scanner);
 		logical = conditional(scanner);
-		if (logical)
-			return (mknode(logical->type, mknode(OR, NULL, pipe), logical));
-		return (mknode(OR, NULL, pipe));
+		return (and_or(OR, pipe, logical));
 	}
 	return (NULL);
 }
@@ -111,4 +109,19 @@ t_node	*command(t_scanner *scanner)
 	}
 	syntax_error(scanner);
 	return (NULL);
+}
+
+static t_node	*and_or(t_node_type type, t_node *pipe, t_node *logical)
+{
+	t_node	*aux;
+
+	if (logical)
+	{
+		aux = logical;
+		while (aux->data.pair.left)
+			aux = aux->data.pair.left;
+		aux->data.pair.left = mknode(type, NULL, pipe);
+		return (logical);
+	}
+	return (mknode(type, NULL, pipe));
 }

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -161,20 +161,41 @@ Test(parser, conditionals)
 
 	scanner = init_scanner("cmd1 && cmd2 && cmd3 && cmd4");
 	root = parse(&scanner);
-	cr_assert(eq(root->type, AND), "Chain of logical AND failed");
-	node = root->data.pair.right;
-	cr_assert(eq(node->type, AND), "Chain of logical AND failed");
-	node = node->data.pair.right;
-	cr_assert(eq(node->type, AND), "Chain of logical AND failed");
+	cr_assert(eq(root->type, AND));
+	cr_assert(eq(root->data.pair.right->type, COMMAND));
+	node = root->data.pair.left;
+	cr_assert(eq(node->type, AND));
+	cr_assert(eq(node->data.pair.right->type, COMMAND));
+	node = node->data.pair.left;
+	cr_assert(eq(node->type, AND));
+	cr_assert(eq(node->data.pair.left->type, COMMAND));
+	cr_assert(eq(node->data.pair.right->type, COMMAND));
 	free_tree(root);
 
 	scanner = init_scanner("cmd1 || cmd2 || cmd3 || cmd4");
 	root = parse(&scanner);
-	cr_assert(eq(root->type, OR), "Chain of logical OR failed");
-	node = root->data.pair.right;
-	cr_assert(eq(node->type, OR), "Chain of logical OR failed");
-	node = node->data.pair.right;
-	cr_assert(eq(node->type, OR), "Chain of logical OR failed");
+	cr_assert(eq(root->type, OR));
+	cr_assert(eq(root->data.pair.right->type, COMMAND));
+	node = root->data.pair.left;
+	cr_assert(eq(node->type, OR));
+	cr_assert(eq(node->data.pair.right->type, COMMAND));
+	node = node->data.pair.left;
+	cr_assert(eq(node->type, OR));
+	cr_assert(eq(node->data.pair.left->type, COMMAND));
+	cr_assert(eq(node->data.pair.right->type, COMMAND));
+	free_tree(root);
+
+	scanner = init_scanner("echo a && echo b || echo c && echo d");
+	root = parse(&scanner);
+	cr_assert(eq(root->type, AND));
+	cr_assert(eq(root->data.pair.right->type, COMMAND));
+	node = root->data.pair.left;
+	cr_assert(eq(node->type, OR));
+	cr_assert(eq(node->data.pair.right->type, COMMAND));
+	node = node->data.pair.left;
+	cr_assert(eq(root->type, AND));
+	cr_assert(eq(node->data.pair.left->type, COMMAND));
+	cr_assert(eq(node->data.pair.right->type, COMMAND));
 	free_tree(root);
 }
 


### PR DESCRIPTION
Working like a charm:
- echo a && echo b || echo c && echo d
- ls && ls && ls && ls || ls

Closes #56 