### PR TITLE
fix(pipe): use array to avoid leaks when creating pipelines

### DIFF
--- a/include/exec.h
+++ b/include/exec.h
@@ -6,7 +6,7 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/13 11:45:35 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/19 10:26:49 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/20 17:57:26 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,16 +24,18 @@
 # include "helpers.h"
 
 # define FORKED_CHILD 0
+# define PIPE_LIMIT 1024
 # define HEREDOC_TEMPFILE "/tmp/heredoc_tempfile"
 
 typedef struct s_context {
 	int		fd[2];
+	int		pid[PIPE_LIMIT];
 	int		fd_close;
+	int		proc;
 	t_byte	retcode;
 	t_bool	error;
 	t_bool	quit;
 	t_bool	pipeline;
-	t_list	*proc_queue;
 }	t_context;
 
 t_bool	execute(t_node *root);
@@ -50,6 +52,7 @@ void	exec_subshell(t_node *node, t_context *ctx);
 t_bool	exec_builtin(char **argv, t_context *ctx);
 
 void	enqueue(long pid, t_context *ctx);
+void	copy_queue(t_context *ctx, t_context aux_ctx);
 void	redirect_io(int saved[], t_context *ctx);
 void	restore_io(int saved[]);
 void	reaper(t_context *ctx);

--- a/src/exec/exec_cmd.c
+++ b/src/exec/exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/15 16:35:36 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/19 11:10:59 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/20 17:35:12 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ static t_bool	is_executable(char *filename, t_context *ctx);
 
 void	exec_command(t_node *node, t_context *ctx)
 {
-	char		**argv;
+	char	**argv;
 
 	argv = expand(node->data.cmd);
 	if (ft_strchr(argv[0], '/') == NULL)

--- a/src/exec/exec_list.c
+++ b/src/exec/exec_list.c
@@ -6,7 +6,7 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/22 22:24:20 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/08 20:56:52 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/20 17:53:47 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,9 +54,9 @@ void	exec_or(t_node *node, t_context *ctx)
 
 static void	wait_queue(t_context *ctx, t_context *aux)
 {
-	if (aux->proc_queue)
+	if (aux->proc)
 	{
-		ctx->proc_queue = aux->proc_queue;
+		copy_queue(ctx, *aux);
 		reaper(ctx);
 	}
 	else

--- a/src/exec/exec_pipe.c
+++ b/src/exec/exec_pipe.c
@@ -6,7 +6,7 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/21 21:30:25 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/19 15:59:37 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/20 17:43:18 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,12 +26,13 @@ void	exec_pipe(t_node *node, t_context *ctx)
 	aux_ctx.fd[STDOUT_FILENO] = pfd[STDOUT_FILENO];
 	aux_ctx.fd_close = pfd[STDIN_FILENO];
 	exec_node(lhs, &aux_ctx);
-	ctx->proc_queue = aux_ctx.proc_queue;
+	copy_queue(ctx, aux_ctx);
 	rhs = node->data.pair.right;
 	aux_ctx = *ctx;
 	aux_ctx.fd[STDIN_FILENO] = pfd[STDIN_FILENO];
 	aux_ctx.fd_close = pfd[STDOUT_FILENO];
 	exec_node(rhs, &aux_ctx);
+	copy_queue(ctx, aux_ctx);
 	close(pfd[STDIN_FILENO]);
 	close(pfd[STDOUT_FILENO]);
 }

--- a/src/exec/exec_utils.c
+++ b/src/exec/exec_utils.c
@@ -6,7 +6,7 @@
 /*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/14 09:29:15 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/03 15:03:34 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/01/20 19:31:18 by mdias-ma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,24 @@
 
 void	enqueue(long pid, t_context *ctx)
 {
-	ft_lstadd_back(&ctx->proc_queue, ft_lstnew((void *)pid));
+	ctx->pid[ctx->proc] = pid;
+	ctx->proc += 1;
+}
+
+void	copy_queue(t_context *ctx, t_context aux)
+{
+	int	i;
+	int	j;
+
+	i = 0;
+	j = 0;
+	ctx->proc = aux.proc;
+	while (aux.pid[j] != 0)
+	{
+		ctx->pid[i] = aux.pid[j];
+		i++;
+		j++;
+	}
 }
 
 void	redirect_io(int saved[], t_context *ctx)


### PR DESCRIPTION
# Description

This commit replaces the linked list with an array in the process queue implementation.