### PR TITLE
docs: add 8th revision of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://game.42sp.org.br/static/assets/achievements/minishellm.png">
+    <img src="https://user-images.githubusercontent.com/102881479/223723896-8bb0e61e-1102-4dd9-b29a-06c4725aa3eb.png">
 </p>
 
 <p align="center">


### PR DESCRIPTION
The minishell's badge doesn't depend anymore of game.42sp.org.br to be displayed. The image is now stored locally.

This avoids the image not being displayed when the image's host is out (error 404).