### PR TITLE
fix: address latest norminette v3.3.55 update incompatibility issue

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,11 +26,11 @@ jobs:
       - uses: actions/checkout@v3
 
       # Runs a set of commands using the runners shell
-      - name: Set up Criterion framework on Ubuntu 22.04
+      - name: Set up Criterion framework and norminette on Ubuntu 22.04
         run: |
-          sudo apt-get install libcriterion-dev
+          sudo apt-get install -y libcriterion-dev
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install norminette
+          python3 -m pip install norminette==3.3.51
       # Runs a single command using the runners shell
       - name: Run norminette validation
         run: norminette include src

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@
 
 The 8th project of 42 cursus syllabus asks students to implement a simplified shell. It's about minishell, as beautiful as a shell.
 
-As the project's subject states, the existence of shells is linked to the very existence of IT. At the time, al developers agreed that _communicating with a computer using aligned 1/0 swiches was seriously irritating_. It was only logical that they came up with the idea of creating a software to communicate with a computer using interactive lines of commands in a language somehat close to the human language.
+As the project's subject states, the existence of shells is linked to the very existence of IT. At the time, all developers agreed that _communicating with a computer using aligned 1/0 swiches was seriously irritating_. It was only logical that they came up with the idea of creating a software to communicate with a computer using interactive lines of commands in a language somewhat close to the human language.
 
 ## How to compile and run the project
 
 #### 1) Copy this repository to your local workstation
 
 ```html
-git@github.com:magalhaesm/minishell.git
+git clone https://github.com/magalhaesm/minishell.git
 ```
 
 #### 2) Install the required libraries to run the functions from readline library
 
 ```html
-sudo apt-get install libreadline6 libreadline6-dev
+sudo apt-get install -y libreadline6 libreadline6-dev
 ```
 
 #### 3) Compile the project with Makefile

--- a/include/exec.h
+++ b/include/exec.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.h                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/13 11:45:35 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/20 17:57:26 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2024/04/04 13:07:57 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,8 @@
 # define PIPE_LIMIT 1024
 # define HEREDOC_TEMPFILE "/tmp/heredoc_tempfile"
 
-typedef struct s_context {
+typedef struct s_context
+{
 	int		fd[2];
 	int		pid[PIPE_LIMIT];
 	int		fd_close;

--- a/include/parser.h
+++ b/include/parser.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/24 09:49:48 by mdias-ma          #+#    #+#             */
-/*   Updated: 2022/12/21 14:40:55 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2024/04/04 13:08:39 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,8 @@
 # include "scanner.h"
 # include "tree.h"
 
-typedef enum e_nonterminal {
+typedef enum e_nonterminal
+{
 	LIST = 0,
 	PIPELINE = LIST,
 	CMD = LIST,

--- a/include/tree.h
+++ b/include/tree.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   tree.h                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/30 15:36:15 by mdias-ma          #+#    #+#             */
-/*   Updated: 2022/12/24 11:03:19 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2024/04/04 13:08:10 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,8 @@
 
 # include "scanner.h"
 
-typedef enum e_node_type {
+typedef enum e_node_type
+{
 	COMMAND,
 	AND,
 	OR,
@@ -30,17 +31,20 @@ typedef enum e_node_type {
 typedef struct s_node	t_node;
 typedef char **			t_command;
 
-typedef struct s_operand {
+typedef struct s_operand
+{
 	t_node	*left;
 	t_node	*right;
 }	t_operand;
 
-typedef union u_node_value {
+typedef union u_node_value
+{
 	t_command	cmd;
 	t_operand	pair;
 }	t_node_value;
 
-typedef struct s_node {
+typedef struct s_node
+{
 	t_node_type		type;
 	t_node_value	data;
 }	t_node;

--- a/src/builtins/cd.c
+++ b/src/builtins/cd.c
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/24 19:00:09 by yde-goes          #+#    #+#             */
-/*   Updated: 2023/01/01 19:15:34 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2024/04/04 13:08:29 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,7 +69,7 @@ static char	*handle_special_cd(char **args)
 	{
 		getcwd(pwd, PATH_MAX);
 		return (pwd);
-	}			
+	}
 	else if (arg_len == 2 && ft_strncmp(args[1], "..", 2) == 0)
 		dir_param = "..";
 	return (dir_param);

--- a/src/table/hash_table.c
+++ b/src/table/hash_table.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   hash_table.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/09 17:39:31 by mdias-ma          #+#    #+#             */
-/*   Updated: 2022/12/15 21:10:47 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2024/04/04 13:08:21 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ t_entry	*find_entry(t_entry *entries, int capacity, char *key)
 				return (entry);
 			}
 			else if (tombstone == NULL)
-					tombstone = entry;
+				tombstone = entry;
 		}
 		else if (ft_strncmp(entry->key, key, ft_strlen(key)) == 0)
 			return (entry);


### PR DESCRIPTION
The latest norminette v3.3.55 doesn't allow students to choose between the K&R or Allman indentation style; instead, it enforces the use of the latter. The K&R indentation style is used in the original Unix kernel, while the Allman style is used in BSD Unix.

Deciding whether to pin the tools used on CD/CI or to keep them updated is a complex question. We must consider factors such as stability versus being up-to-date, security, long-term maintenance, and compatibility. Therefore, I opted for a balanced approach, pinning the Norminette version to v3.3.51, which was the latest version at the time this project was developed and its only major tool.

Since the project is finished, it doesn't require long-term maintenance, nor will it have major security issues since the tool used is only a code formatter. Therefore, I addressed the issue of compatibility as our whole project is structured to adhere to norminette v3.3.51.

However, while I was at it, I decided to make some minor changes to the code to conform to the new norm and only left the critical ones. The norminette v3.3.55 is stricter than the old one regarding preprocessor definitions. The log below references the file `include/hash_table.h`: 

```
# define RIP ((void *)1)

Error: PREPROC_CONSTANT     (line:  19, col:  14):      Preprocessor statement must only contain constant defines
```

To sum up, this PR ensures that our CI/CD doesn't break due to external changes if we further tinker with this hard and amusing project.