### PR TITLE
fix: remove overwritting when reaching prompt line limit

### DIFF
--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,13 +6,13 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/08 11:06:36 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/01/20 16:47:16 by yde-goes         ###   ########.fr       */
+/*   Updated: 2024/06/06 14:03:51 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-#define GREEN_PROMPT "\e[m\e[1;32m❯ \e[m"
+#define GREEN_PROMPT "\001\e[m\e[1;32m❯ \e[m\002"
 
 static void	msh_loop(void);
 static void	prompt_logo(void);


### PR DESCRIPTION
This small PR fixes the problem of the user input being overwritten in the same line instead of continuing in the line below it. It was necessary to wrap `GREEN_PROMPT` around `\001`an `\002`.

```
   Current implementation:
    \001 (^A) start non-visible characters
    \002 (^B) end non-visible characters
   all characters except \001 and \002 (following a \001) are copied to
   the returned string; all characters except those between \001 and
   \002 are assumed to be `visible'.
```

Source: [Escape non printing characters in a function for a bash prompt](https://superuser.com/questions/301353/escape-non-printing-characters-in-a-function-for-a-bash-prompt)